### PR TITLE
add BCWI (plus K) abstraction elimination

### DIFF
--- a/AIT.lhs
+++ b/AIT.lhs
@@ -247,6 +247,7 @@ Bitstring functions -----------------------------------------------------
 >   "nf_size" -> nl .              show . size . nf . toDB $ prog
 >   "comb_nf" -> nl .        show . strongCL . toCL . toDB $ prog
 >   "comb"    -> nl .        show . toCL . optimize . toDB $ prog
+>   "bcw"     -> nl .    showBCW . toBCW . optimize . toDB $ prog
 >   "bcl"     -> nl .      encode . toCL . optimize . toDB $ prog
 >   "diagram" -> elems   . diagram False . optimize . toDB $ prog
 >   "Diagram" -> elems   . diagram  True . optimize . toDB $ prog


### PR DESCRIPTION
Note: This is a quick and dirty hack because I needed a BCW abstraction elimination algorithm for `#esoteric`. There's plenty of room for cleanup. The main question is whether extending the `CL` type with new combinators is desirable; the alternative is to have a new type... at the risk of having one for each subset of combinators that we'd like to support.

Depending on the answer, the reduction engine for CL could be extended as well.