### PR TITLE
Update BLC.tex, fix typo

### DIFF
--- a/BLC.tex
+++ b/BLC.tex
@@ -151,7 +151,7 @@ Define (for any $M,P,Q,\ldots,R$)
 \idx{M}{0} & \equiv & M\ \Ct \\
 \idx{M}{i+1} & \equiv & \idx{(M\ \Cf)}{i} \\
 %\Cnull& \equiv & \tup{\lambda a\ b\ c.\ \Cf, \Ct} \\
-\CY & \equiv & \lambda f.((\lambda x.x\ x)(\lambda x.f\ (x\ x))) \\
+\CY & \equiv & \lambda f.((\lambda x.f\ (x\ x))(\lambda x.f\ (x\ x))) \\
 \COm & \equiv & (\lambda x.x\ x)(\lambda x.x\ x)
 \end{eqnarray*}
 


### PR DESCRIPTION
fix typo on Y combinator on section 2.1

<img width="565" alt="image" src="https://user-images.githubusercontent.com/770012/226142115-39029a43-19a5-4004-a651-bc144f03eefa.png">
